### PR TITLE
Remove unused team_id

### DIFF
--- a/lib/event_controller.rb
+++ b/lib/event_controller.rb
@@ -51,12 +51,11 @@ class EventController < Sinatra::Base
 
   def handle_event(data)
     if data['type'] == 'event_callback'
-      team_id = data['team_id']
       event_data = data['event']
 
       if message?(event_data) && !message_from_bot?(event_data)
         Logger.info("Receives Data #{event_data}")
-        message_handler.handle(team_id, event_data)
+        message_handler.handle(event_data)
       end
     end
   end

--- a/lib/foreman_messager.rb
+++ b/lib/foreman_messager.rb
@@ -5,12 +5,8 @@ class ForemanMessager
     @bot = bot
   end
 
-  def update_team_id(team_id)
-    @team_id = team_id
-  end
-
   def send(message)
-    @bot.send(message, @team_id, foreman_id)
+    @bot.send(message, foreman_id)
   end
 
   private

--- a/lib/message_handler.rb
+++ b/lib/message_handler.rb
@@ -21,10 +21,9 @@ class MessageHandler < FeatureFlag
     @alert = AlertForeman.new(@foremanMessager)
   end
 
-  def handle(team_id, event_data)
+  def handle(event_data)
     recipient = event_data['channel'] || event_data['user']
-    @foreman_messager.update_team_id(team_id)
-    data = format_data(team_id, event_data)
+    data = format_data(event_data)
     return data[:user_message] if data[:user_message].nil?
     returned_command = @request_parser.parse(data)
 
@@ -52,14 +51,13 @@ class MessageHandler < FeatureFlag
     response
   end
 
-  def format_data(team_id, event_data)
+  def format_data(event_data)
     {
       user_message: event_data['text'],
       user_id: event_data['user'],
       user_name: @user_info.real_name(event_data['user']),
       user_email: @user_info.email(event_data['user']),
       channel_id: event_data['channel'],
-      team_id: team_id,
       mark_all_out: @mark_all_out,
       alert: @alert,
     }

--- a/spec/message_handler_spec.rb
+++ b/spec/message_handler_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe MessageHandler do
   let(:fake_bot) { FakeBot.new }
   let(:fake_mark_all_out) { FakeMarkAllOut.new }
   let(:fake_user_info_provider) { FakeUserInfoProvider.new }
-  let(:team_id) { "T026MULUJ" }
   let(:recipient) { "D3S6XE6SZ" }
   let(:channel_id) { "CHANNELID" }
 
@@ -96,7 +95,7 @@ RSpec.describe MessageHandler do
     user_message = args[:user_message]
     new_recipient = args[:new_recipient] || recipient
     event_data = create_event_data(user_message, new_recipient)
-    message_handler.handle(team_id, event_data)
+    message_handler.handle(event_data)
   end
 
   def create_event_data(message, recipient)

--- a/spec/request_parser_spec.rb
+++ b/spec/request_parser_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe RequestParser do
     request = {
       user_message: "remind",
       channel_id: "asdf",
-      team_id: "team id",
     }
 
     expect(user_request.parse(request)).to be_a(Commands::Reminder)


### PR DESCRIPTION
`team_id` is really a workspace id, and we don't seem to make any real use of it.

https://api.slack.com/faq#team_vs._workspace