### PR TITLE
Adds tag for the tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,6 +82,11 @@ RSpec.configure do |config|
   config.filter_gems_from_backtrace 'rack', 'rack-test', 'sinatra'
   config.order = :random
 
+  # bundle exec rspec --tag fast
+  config.define_derived_metadata(file_path: /spec\/unit/) do |meta|
+    meta[:fast] = true
+  end
+
   DataMapper.setup(:default, "sqlite::memory:")
 
   config.before(:each) do


### PR DESCRIPTION
What about adding flags for the tests? That could help to speed up the development by leaving the e2e tests apart when developing and only run them when required. The pipeline would run every kind of tests